### PR TITLE
add '--shape' argument to OTF parser rather than hard-coded `(256, 256)`

### DIFF
--- a/src/sim_recon/cli/otf.py
+++ b/src/sim_recon/cli/otf.py
@@ -18,6 +18,7 @@ def main() -> None:
         output_directory=namespace.output_directory,
         overwrite=namespace.overwrite,
         cleanup=namespace.cleanup,
+        xy_shape=namespace.xy_shape,
         **otf_kwargs,
     )
 

--- a/src/sim_recon/cli/parsing.py
+++ b/src/sim_recon/cli/parsing.py
@@ -111,6 +111,15 @@ def parse_otf_args(
         help="If specified, files created during the reconstruction process will not be cleaned up",
     )
 
+    parser.add_argument(
+        "--shape",
+        dest="xy_shape",
+        default=None,
+        nargs=2,
+        type=int,
+        help="Takes 2 integers (X Y), specifying the shape to crop PSFs to before converting",
+    )
+
     _add_general_args(parser)
 
     namespace, unknown = parser.parse_known_args(args)

--- a/src/sim_recon/files/images.py
+++ b/src/sim_recon/files/images.py
@@ -411,8 +411,12 @@ def _apply_crop(
         target_yx_shape = np.asarray(xy_shape[::-1], dtype=np.uint16)
         current_yx_shape = np.asarray(array.shape[1:], dtype=np.uint16)
         crop_amount = current_yx_shape - target_yx_shape
-        min_bounds = crop_amount // 2
-        max_bounds = current_yx_shape - crop_amount // 2
+
+        # Crops more off the max than the min if not divisible by 2:
+        edge_crop_amount = crop_amount / 2
+        min_bounds = np.floor(edge_crop_amount).astype(np.uint16)
+        max_bounds = current_yx_shape - np.ceil(edge_crop_amount).astype(np.uint16)
+
         array_slices[-2] = slice(min_bounds[0], max_bounds[0])  # x
         array_slices[-1] = slice(min_bounds[1], max_bounds[1])  # y
     elif crop > 0 and crop <= 1:

--- a/src/sim_recon/files/images.py
+++ b/src/sim_recon/files/images.py
@@ -404,19 +404,25 @@ def _apply_crop(
     xy_shape: tuple[int, int] | None = None,
     crop: float = 0,
 ) -> NDArray[Any]:
+    assert array.ndim > 1, "Images must have > 1 dimension"
+    array_slices = [slice(None)] * array.ndim
     if xy_shape is not None:
+        logger.info("Cropping to X, Y: %i, %i", *xy_shape)
         target_yx_shape = np.asarray(xy_shape[::-1], dtype=np.uint16)
         current_yx_shape = np.asarray(array.shape[1:], dtype=np.uint16)
         crop_amount = current_yx_shape - target_yx_shape
         min_bounds = crop_amount // 2
         max_bounds = current_yx_shape - crop_amount // 2
-        array = array[:, min_bounds[0] : max_bounds[0], min_bounds[1] : max_bounds[1]]
+        array_slices[-2] = slice(min_bounds[0], max_bounds[0])  # x
+        array_slices[-1] = slice(min_bounds[1], max_bounds[1])  # y
     elif crop > 0 and crop <= 1:
+        logger.info("Cropping by %g%%", crop * 100)
         yx_shape = np.asarray(array.shape[1:], dtype=np.uint16)
         min_bounds = np.round((yx_shape * crop) / 2).astype(np.uint16)
         max_bounds = yx_shape - min_bounds
-        array = array[:, min_bounds[0] : max_bounds[0], min_bounds[1] : max_bounds[1]]
-    return array
+        array_slices[-2] = slice(min_bounds[0], max_bounds[0])  # x
+        array_slices[-1] = slice(min_bounds[1], max_bounds[1])  # y
+    return array[*array_slices]
 
 
 def dv_to_tiff(

--- a/src/sim_recon/main.py
+++ b/src/sim_recon/main.py
@@ -45,6 +45,7 @@ def sim_psf_to_otf(
     output_directory: str | PathLike[str] | None = None,
     overwrite: bool = False,
     cleanup: bool = True,
+    xy_shape: tuple[int, int] | None = None,
     **otf_kwargs: Any,
 ) -> None:
     conf = load_configs(config_path)
@@ -54,6 +55,7 @@ def sim_psf_to_otf(
         output_directory=output_directory,
         overwrite=overwrite,
         cleanup=cleanup,
+        xy_shape=xy_shape,
         **otf_kwargs,
     )
 

--- a/src/sim_recon/otfs.py
+++ b/src/sim_recon/otfs.py
@@ -69,6 +69,7 @@ def convert_psfs_to_otfs(
     output_directory: str | PathLike[str] | None = None,
     overwrite: bool = False,
     cleanup: bool = True,
+    xy_shape: tuple[int, int] | None = None,
     **kwargs: Any,
 ) -> list[Path]:
     completed_otfs: list[Path] = []
@@ -97,6 +98,7 @@ def convert_psfs_to_otfs(
                     wavelength=wavelengths.emission_nm_int,
                     overwrite=overwrite,
                     cleanup=cleanup,
+                    xy_shape=xy_shape,
                     **otf_kwargs,
                 )
             except Exception:
@@ -129,6 +131,7 @@ def psf_to_otf(
     otf_path: str | PathLike[str],
     overwrite: bool = False,
     cleanup: bool = True,
+    xy_shape: tuple[int, int] | None = None,
     **kwargs: Any,
 ) -> Path | None:
     otf_path = Path(otf_path)
@@ -154,7 +157,7 @@ def psf_to_otf(
         psf_path,
         get_temporary_path(otf_path.parent, f".{psf_path.stem}", suffix=".tiff"),
         delete=cleanup,
-        xy_shape=(256, 256),
+        xy_shape=xy_shape,
     ) as tiff_path:
         make_otf_kwargs["psf"] = str(tiff_path)
         make_otf_kwargs["out_file"] = str(otf_path)


### PR DESCRIPTION
Rather than hardcoding the crop shape, I've allowed made it a command line argument.