### PR TITLE
Determine shape from DV header and use that to ensure correct indexing

### DIFF
--- a/src/sim_recon/files/images.py
+++ b/src/sim_recon/files/images.py
@@ -101,37 +101,43 @@ def get_mrc_header_array(
     )
 
 
-def get_wavelengths_from_dv(dv: mrc.Mrc) -> Generator[Wavelengths, None, None]:
+def get_dv_axis_order_from_header(dv: mrc.Mrc) -> str:
+    sequence = dv.header.ImgSequence
+    if sequence == 0:
+        return "wtzyx"
+    elif sequence == 1:
+        return "tzwyx"
+    elif sequence == 2:
+        return "twzyx"
+    raise ValueError("DV header is invalid, ImgSequence must be 0, 1, or 2")
+
+
+def get_dv_axis_sizes(dv: mrc.Mrc) -> dict[str, int]:
     header = dv.header
+    return {
+        "w": header.NumWaves,
+        "t": header.NumTimes,
+        "z": header.Num[2] // (header.NumWaves * header.NumTimes),
+        "y": header.Num[1],
+        "x": header.Num[0],
+    }
+
+
+def get_wavelengths_from_dv(dv: mrc.Mrc) -> Generator[Wavelengths, None, None]:
     ext_floats = dv.extFloats
 
-    sequence = header.ImgSequence  # (0,1,2 = (ZTW or WZT or ZWT)
-    num_waves = header.NumWaves
-    num_times = header.NumTimes
-    dz = header.Num[2] // (num_waves * num_times)
+    axis_order = get_dv_axis_order_from_header(dv)
+    axis_sizes = get_dv_axis_sizes(dv)
 
-    header_shape = {
-        0: (num_waves, num_times, dz),
-        1: (
-            num_times,
-            dz,
-            num_waves,
-        ),
-        2: (num_times, num_waves, dz),
-    }[sequence]
-
+    # Extended header is per frame, so don't include yx
+    header_shape = tuple(axis_sizes[ax] for ax in axis_order[:3])
     ext_header = ext_floats.reshape(*header_shape, -1)
 
-    for c in range(num_waves):
-        indexes = {
-            0: (0, 0, dz),
-            1: (
-                0,
-                0,
-                c,
-            ),
-            2: (0, c, 0),
-        }[sequence]
+    wavelength_index = axis_order.index("w")
+
+    for c in range(axis_sizes["w"]):
+        indexes = [0, 0, 0]
+        indexes[wavelength_index] = c
         yield Wavelengths(
             # indexed as [image frame index, float index]
             excitation_nm=ext_header[*indexes, 10],  # exWavelen index is 10
@@ -339,42 +345,39 @@ def get_image_data(
 
     array = read_mrc_bound_array(file_path)
     xyz_resolutions = array.Mrc.header.d
-    # ImgSequence: 0=wtzyx, 1=tzwyx, 2=twzyx (numpy axis order)
-    channel_index = {0: -5, 1: -3, 2: -4}[array.Mrc.header.ImgSequence]
+    if xyz_resolutions[0] != xyz_resolutions[1]:
+        raise ValueError("DV file pixels are not square")
+
+    axis_order = get_dv_axis_order_from_header(array.Mrc)
+    axis_sizes = get_dv_axis_sizes(array.Mrc)
+    channel_index = axis_order.index("w")
+    dv_shape = tuple(axis_sizes[ax] for ax in axis_order)
+
+    # Essentially unsqueeze the axes to ensure the indexing is correct
+    array = array.reshape(dv_shape)
 
     channels: list[ImageChannel] = []
     wavelengths_tuple = tuple(get_wavelengths_from_dv(array.Mrc))
     num_channels = len(wavelengths_tuple)
 
-    if array.ndim == 3 and num_channels == 1:
-        # I suspect Cockpit may not be writing the metadata correctly for a
-        # Z-stack experiment, as I think ImgSequence` should be 0 or 2 when
-        # there are axes present for wavelength or time).
-        #
-        # By separately checking the number of channels via the extended
-        # header, we can be confident that this array shouldn't be split into
-        # multiple channels, so this shouldn't break anything.
-        channels = (ImageChannel(array, wavelengths=wavelengths_tuple[0]),)
-    else:
-        channel_dim_size = array.shape[channel_index]
-        channel_index += channel_dim_size  # Make it a positive index
+    channel_dim_size = array.shape[channel_index]
 
-        if channel_dim_size != num_channels:
-            raise IndexError(
-                "The number of channels defined in the extended header "
-                f"({num_channels}) don't match the size ({channel_dim_size}) of "
-                f"the expected dimension ({channel_index})"
-            )
+    if channel_dim_size != num_channels:
+        raise IndexError(
+            "The number of channels defined in the extended header "
+            f"({num_channels}) don't match the size ({channel_dim_size}) of "
+            f"the expected dimension ({channel_index})"
+        )
 
-        for c, wavelengths in enumerate(wavelengths_tuple):
-            channel_slice: list[slice | int] = [slice(None)] * len(array.shape)
-            channel_slice[channel_index] = c
-            channels.append(
-                ImageChannel(
-                    array[*channel_slice],
-                    wavelengths,
-                )
+    for c, wavelengths in enumerate(wavelengths_tuple):
+        channel_slice: list[slice | int] = [slice(None)] * len(array.shape)
+        channel_slice[channel_index] = c
+        channels.append(
+            ImageChannel(
+                array[*channel_slice].squeeze(),
+                wavelengths,
             )
+        )
     return ImageData(
         channels=tuple(channels),
         # Get resolution values from DV file (they get applied to TIFFs later)


### PR DESCRIPTION
In fixing the PSF splitting problem with #10, I managed to create a new problem for the reconstructions (less breaking but it was slicing wrong). It is better to use the header as the ground truth for what the shape should be, so I'm expanding the array out based on the expected shape, and using the header info to determine the channel index.