### PR TITLE
`write_tiff`: add `overwrite` argument

### DIFF
--- a/src/sim_recon/otfs.py
+++ b/src/sim_recon/otfs.py
@@ -134,12 +134,6 @@ def psf_to_otf(
     otf_path = Path(otf_path)
     psf_path = Path(psf_path)
     logger.info("Generating OTF from %s: %s", otf_path, psf_path)
-    if otf_path.is_file():
-        if overwrite:
-            logger.warning("Overwriting file %s", otf_path)
-            otf_path.unlink()
-        else:
-            raise FileExistsError(f"File {otf_path} already exists")
 
     make_otf_kwargs: dict[str, Any] = dict(
         inspect.signature(make_otf).parameters.items()
@@ -154,7 +148,7 @@ def psf_to_otf(
         psf_path,
         get_temporary_path(otf_path.parent, f".{psf_path.stem}", suffix=".tiff"),
         delete=cleanup,
-        xy_shape=(256, 256),
+        overwrite=overwrite,
     ) as tiff_path:
         make_otf_kwargs["psf"] = str(tiff_path)
         make_otf_kwargs["out_file"] = str(otf_path)

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -145,6 +145,7 @@ def reconstruct_from_processing_info(processing_info: ProcessingInfo) -> Path:
         processing_info.output_path,
         ImageChannel(rec_array, wavelengths=processing_info.wavelengths),
         pixel_size_microns=float(processing_info.kwargs["xyres"]) / zoomfact,
+        overwrite=True,
     )
     logger.debug(
         "Reconstruction of %s saved in %s",


### PR DESCRIPTION
Sometimes things could fail between the check, clearing the old files, before the new files were ready to be written, which also caused confusing logs.

- Checks for existing files
- Uses `mode="x"` for writing TIFF (with `tifffile.TiffWriter`)