### PR TITLE
Access and use the defaults properly from the the function signature `Parameter`s

### DIFF
--- a/src/sim_recon/otfs.py
+++ b/src/sim_recon/otfs.py
@@ -138,9 +138,16 @@ def psf_to_otf(
     psf_path = Path(psf_path)
     logger.info("Generating OTF from %s: %s", otf_path, psf_path)
 
-    make_otf_kwargs: dict[str, Any] = dict(
-        inspect.signature(make_otf).parameters.items()
-    )
+    make_otf_kwargs: dict[str, Any] = {
+        param.name: param.default
+        for param in inspect.signature(make_otf).parameters.values()
+        if param.default != param.empty  # Check if default is set
+        and param.kind
+        not in (
+            param.POSITIONAL_ONLY,
+            param.VAR_POSITIONAL,
+        )  # Don't include positional-only options
+    }
 
     for k, v in kwargs.items():
         # Only use kwargs that are accepted by make_otf


### PR DESCRIPTION
After changing a config, I got an error about `leavekz` having an invalid value. Turns out getting the defaults from the function signature wasn't working as I'd remembered. This is now working as expected.