### PR TITLE
Use pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.6.5
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.19.2
+    hooks:
+      - id: gitleaks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ managed = true
 dev-dependencies = [
     "pytest>=8.2.2",
     "pytest-cov>=5.0.0",
+    "pre-commit",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
I looked into using these for the docs but it gets incredibly messy with environments or slow trying to get the python help text, but these options looked useful. 