### PR TITLE
simplify parsing (only parse once)

### DIFF
--- a/docs/help/sim_otf.txt
+++ b/docs/help/sim_otf.txt
@@ -1,15 +1,16 @@
-usage: sim-otf [-c CONFIG_PATH] [-p PSF_PATHS [PSF_PATHS ...]]
+usage: sim-otf [-h] -c CONFIG_PATH -p PSF_PATHS [PSF_PATHS ...]
                [-o OUTPUT_DIRECTORY] [--overwrite] [--no-cleanup]
                [--shape XY_SHAPE XY_SHAPE] [-v] [--no-progress]
                [--nphases NPHASES] [--ls LS] [--na NA] [--nimm NIMM]
                [--background BACKGROUND] [--beaddiam BEADDIAM] [--angle ANGLE]
                [--nocompen NOCOMPEN] [--5bands]
                [--fixorigin FIXORIGIN FIXORIGIN]
-               [--leavekz LEAVEKZ LEAVEKZ LEAVEKZ] [--I2M I2M] [-h]
+               [--leavekz LEAVEKZ LEAVEKZ LEAVEKZ] [--I2M I2M]
 
 SIM PSFs to OTFs
 
 options:
+  -h, --help            show this help message and exit
   -c CONFIG_PATH, --config-path CONFIG_PATH
                         Path to the root config that specifies the paths to
                         the OTFs and the other configs
@@ -31,7 +32,6 @@ options:
   -v, --verbose         Show more logging
   --no-progress         turn off progress bars (only has an effect if tqdm is
                         installed)
-  -h, --help            show this help message and exit
 
 Overrides:
   Arguments that override configured values. Defaults stated are only used

--- a/docs/help/sim_recon.txt
+++ b/docs/help/sim_recon.txt
@@ -1,4 +1,4 @@
-usage: sim-recon [-c CONFIG_PATH] [-d SIM_DATA_PATHS [SIM_DATA_PATHS ...]]
+usage: sim-recon [-h] -c CONFIG_PATH -d SIM_DATA_PATHS [SIM_DATA_PATHS ...]
                  [-o OUTPUT_DIRECTORY] [--overwrite] [--no-cleanup]
                  [--keep-split] [--parallel] [-v] [--no-progress]
                  [--ndirs NDIRS] [--nphases NPHASES] [--nordersout NORDERSOUT]
@@ -19,11 +19,12 @@ usage: sim-recon [-c CONFIG_PATH] [-d SIM_DATA_PATHS [SIM_DATA_PATHS ...]]
                  [--besselExWave BESSELEXWAVE] [--besselNA BESSELNA]
                  [--deskew DESKEW] [--deskewshift DESKEWSHIFT] [--noRecon]
                  [--cropXY CROPXY] [--xyres XYRES] [--zres ZRES]
-                 [--zresPSF ZRESPSF] [--wavelength WAVELENGTH] [-h]
+                 [--zresPSF ZRESPSF] [--wavelength WAVELENGTH]
 
 Reconstruct SIM data
 
 options:
+  -h, --help            show this help message and exit
   -c CONFIG_PATH, --config-path CONFIG_PATH
                         Path to the root config that specifies the paths to
                         the OTFs and the other configs
@@ -43,7 +44,6 @@ options:
   -v, --verbose         Show more logging
   --no-progress         turn off progress bars (only has an effect if tqdm is
                         installed)
-  -h, --help            show this help message and exit
 
 Overrides:
   Arguments that override configured values. Defaults stated are only used

--- a/src/sim_recon/cli/parsing/otf_view.py
+++ b/src/sim_recon/cli/parsing/otf_view.py
@@ -44,7 +44,7 @@ def parse_args(
 
     add_general_args(parser)
 
-    return parser.parse_args(args)
+    return parser.parse_known_args(args)[0]  # throw away unknown args
 
 
 if __name__ == "__main__":

--- a/src/sim_recon/cli/parsing/shared.py
+++ b/src/sim_recon/cli/parsing/shared.py
@@ -4,17 +4,9 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
+    from typing import Any
+    from collections.abc import Container
     from ...settings.formatting import SettingFormat
-
-
-def add_help(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "-h",
-        "--help",
-        action="help",
-        default=argparse.SUPPRESS,
-        help="show this help message and exit",
-    )
 
 
 def add_general_args(parser: argparse.ArgumentParser) -> None:
@@ -30,21 +22,6 @@ def add_general_args(parser: argparse.ArgumentParser) -> None:
         dest="use_tqdm",
         help="turn off progress bars (only has an effect if tqdm is installed)",
     )
-
-
-def handle_required(
-    parser: argparse.ArgumentParser,
-    namespace: argparse.Namespace,
-    *required: tuple[str, str],
-):
-    missing_arguments: list[str] = []
-    for print_name, dest in required:
-        if getattr(namespace, dest, None) is None:
-            missing_arguments.append(print_name)
-    if missing_arguments:
-        parser.error(
-            "the following arguments are required: %s" % ", ".join(missing_arguments)
-        )
 
 
 def add_override_args_from_formatters(
@@ -71,3 +48,12 @@ def add_override_args_from_formatters(
                 required=False,
                 help=formatter.help_string,
             )
+
+
+def namespace_extract_to_dict(
+    namespace: argparse.Namespace, args: Container[str], allow_none: bool = True
+) -> dict[str, Any]:
+    key_value_generator = ((k, v) for k, v in vars(namespace).items() if k in args)
+    if allow_none:
+        return dict(key_value_generator)
+    return {k: v for k, v in key_value_generator if v is not None}


### PR DESCRIPTION
- No longer parses before and after adding the override arguments, which allows some simplification around required args and `--help`.
- `namespace_extract_to_dict` gets kwargs dict from `argparse.Namespace` item and a container of argument names.