### PR TITLE
Include-defaults-in-recon-config

### DIFF
--- a/src/sim_recon/otfs.py
+++ b/src/sim_recon/otfs.py
@@ -15,6 +15,7 @@ from .files.utils import (
     redirect_output_to,
 )
 from .settings import ConfigManager
+from .settings.formatting import formatters_to_default_value_kwargs, OTF_FORMATTERS
 from .progress import get_progress_wrapper, get_logging_redirect
 
 if TYPE_CHECKING:
@@ -135,16 +136,7 @@ def psf_to_otf(
     psf_path = Path(psf_path)
     logger.info("Generating OTF from %s: %s", otf_path, psf_path)
 
-    make_otf_kwargs: dict[str, Any] = {
-        param.name: param.default
-        for param in inspect.signature(make_otf).parameters.values()
-        if param.default != param.empty  # Check if default is set
-        and param.kind
-        not in (
-            param.POSITIONAL_ONLY,
-            param.VAR_POSITIONAL,
-        )  # Don't include positional-only options
-    }
+    make_otf_kwargs = formatters_to_default_value_kwargs(OTF_FORMATTERS)
 
     for k, v in kwargs.items():
         # Only use kwargs that are accepted by make_otf

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -20,6 +20,7 @@ from .images.dv import write_dv
 from .images.tiff import read_tiff, write_tiff, get_combined_array_from_tiffs
 from .images.dataclasses import ImageChannel, Wavelengths, ProcessingInfo
 from .settings import ConfigManager
+from .settings.formatting import formatters_to_default_value_kwargs, RECON_FORMATTERS
 from .progress import get_progress_wrapper, get_logging_redirect
 
 if TYPE_CHECKING:
@@ -321,8 +322,11 @@ def _prepare_config_kwargs(
     otf_path: str | PathLike[str],
     **config_kwargs: Any,
 ) -> dict[str, Any]:
+    # Get the default values (for settings with default values)
+    kwargs = formatters_to_default_value_kwargs(RECON_FORMATTERS)
+
     # Use the configured per-wavelength settings
-    kwargs = conf.get_reconstruction_config(emission_wavelength)
+    kwargs.update(conf.get_reconstruction_config(emission_wavelength))
 
     # config_kwargs override those any config defaults set
     kwargs.update(config_kwargs)

--- a/src/sim_recon/settings/formatting.py
+++ b/src/sim_recon/settings/formatting.py
@@ -263,3 +263,13 @@ RECON_FORMATTERS: dict[str, SettingFormat] = {
     #     description="Write command line to MRC/DV header (may cause issues with bioformats)",
     # ),
 }
+
+
+def formatters_to_default_value_kwargs(
+    formatters: dict[str, SettingFormat]
+) -> dict[str, Any]:
+    return {
+        setting_name: setting_format.default_value
+        for setting_name, setting_format in formatters.items()
+        if setting_format.default_value is not None
+    }


### PR DESCRIPTION
By setting the defaults from the formatters, I'm ensuring the parser descriptions are correct (if a default value was changed in cudasirecon I would update the defaults to match as soon as I was aware, but this way the docs would be correct for this package regardless) and everything is explicitly defined.

I came across this issue because I need the `zzoom` and `zoomfact` values to be known for the purpose of writing the TIFFs and this was failing when they weren't defined in the config or command line, so I thought it was best to ensure the values are explicit, rather than hoping they do still match the defaults of cudasirecon.