### PR TITLE
Allow-non-square-pixel-sizes

### DIFF
--- a/src/sim_recon/images/__init__.py
+++ b/src/sim_recon/images/__init__.py
@@ -58,7 +58,7 @@ def dv_to_tiff(
     write_tiff(
         tiff_path,
         *image_data.channels,
-        pixel_size_microns=image_data.resolution.xy,
+        pixel_size_microns=image_data.resolution.y,
         overwrite=overwrite,
     )
     return Path(tiff_path)

--- a/src/sim_recon/images/dataclasses.py
+++ b/src/sim_recon/images/dataclasses.py
@@ -37,7 +37,8 @@ class ImageChannel:
 
 @dataclass(slots=True, frozen=True)
 class ImageResolution:
-    xy: float | None
+    x: float | None
+    y: float | None
     z: float | None
 
 

--- a/src/sim_recon/images/dv.py
+++ b/src/sim_recon/images/dv.py
@@ -154,7 +154,7 @@ def get_image_data(
     array = read_mrc_bound_array(file_path)
     xyz_resolutions = array.Mrc.header.d
     if xyz_resolutions[0] != xyz_resolutions[1]:
-        raise ValueError("DV file pixels are not square")
+        logger.warning("Pixels are not square in %s", file_path)
 
     axis_order = get_dv_axis_order_from_header(array.Mrc)
     axis_sizes = get_dv_axis_sizes(array.Mrc)
@@ -190,6 +190,8 @@ def get_image_data(
         channels=tuple(channels),
         # Get resolution values from DV file (they get applied to TIFFs later)
         resolution=ImageResolution(
-            xy=xyz_resolutions[0], z=xyz_resolutions[2]  # Assumes square pixels
+            x=xyz_resolutions[0],
+            y=xyz_resolutions[1],
+            z=xyz_resolutions[2],  # Assumes square pixels
         ),
     )

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -407,7 +407,10 @@ def _prepare_files(
 
     # Resolution defaults to metadata values but kwargs can override
     config_kwargs["zres"] = config_kwargs.get("zres", image_data.resolution.z)
-    config_kwargs["xyres"] = config_kwargs.get("xyres", image_data.resolution.xy)
+
+    # Assume xyres is the y pixel size (matches the assumption used in cudasirecon, allows for deskew)
+    # see https://github.com/scopetools/cudasirecon/blob/main/src/cudaSirecon/mrc.h
+    config_kwargs["xyres"] = config_kwargs.get("xyres", image_data.resolution.y)
 
     # Safer to assume they match (if not given) than use cudasirecon's default value of 0.15:
     config_kwargs["zresPSF"] = config_kwargs.get("zresPSF", config_kwargs["zres"])

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -136,10 +136,11 @@ def reconstruct_from_processing_info(processing_info: ProcessingInfo) -> Path:
     #     processing_info.config_path,
     # )
     logger.info("Reconstructed %s", processing_info.image_path)
+    recon_pixel_size = float(processing_info.kwargs["xyres"]) / zoomfact
     write_tiff(
         processing_info.output_path,
         ImageChannel(rec_array, wavelengths=processing_info.wavelengths),
-        pixel_size_microns=float(processing_info.kwargs["xyres"]) / zoomfact,
+        xy_pixel_size_microns=(recon_pixel_size, recon_pixel_size),
         overwrite=True,
     )
     logger.debug(
@@ -451,8 +452,9 @@ def _prepare_files(
                     write_tiff(
                         split_file_path,
                         channel,
-                        pixel_size_microns=float(
-                            config_kwargs["xyres"]  # Cast as stored as Decimal
+                        xy_pixel_size_microns=(
+                            image_data.resolution.x,
+                            image_data.resolution.y,
                         ),
                     )
 


### PR DESCRIPTION
cudasirecon allows non-square pixel sizes for the purpose of skewed images, and this is also useful for converting OTFs, which may not have square pixel sizes. This change allows the behaviour to be matched.