### PR TITLE
`image_resolution_from_mrc`: create and use it in `get_image_data` & `write_dv`

### DIFF
--- a/src/sim_recon/images/dataclasses.py
+++ b/src/sim_recon/images/dataclasses.py
@@ -45,9 +45,9 @@ class ImageChannel(Generic[OptionalWavelengths]):
 
 @dataclass(slots=True, frozen=True)
 class ImageResolution:
-    x: float | None
-    y: float | None
-    z: float | None
+    x: float
+    y: float
+    z: float
 
 
 @dataclass(slots=True, frozen=True)


### PR DESCRIPTION
- Ensures DV pixel size is handled consistently
- Fixes incorrect reconstruction DV pixel size
