### PR TITLE
Changed otf view display amplitude and phase and not real and imaginary

### DIFF
--- a/src/sim_recon/otf_view.py
+++ b/src/sim_recon/otf_view.py
@@ -123,7 +123,7 @@ def _create_otf_plots(array: NDArray[Any]) -> Figure:
         if i == 0:
             axes[0, i].set_ylabel("Amplitude")
         axes[0, i].imshow(
-            gamma_adjust(array[i, ::-1, :].real, 0.3),
+            gamma_adjust(array[i, ::-1, :].absolute, 0.3),
             vmin=-0.1,
             vmax=1,
             cmap="plasma",
@@ -135,7 +135,7 @@ def _create_otf_plots(array: NDArray[Any]) -> Figure:
         if i == 0:
             axes[1, i].set_ylabel("Phase")
         axes[1, i].imshow(
-            gamma_adjust(array[i, ::-1, :].imag, 0.3),
+            gamma_adjust(array[i, ::-1, :].angle, 1),
             vmin=-0.1,
             vmax=0.1,
             cmap="gray",

--- a/src/sim_recon/otf_view.py
+++ b/src/sim_recon/otf_view.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 import logging
 from pathlib import Path
+import numpy as np
 import matplotlib.pyplot as plt
 from typing import TYPE_CHECKING
-import numpy as np
 
 from .progress import get_progress_wrapper, get_logging_redirect
 from .images.dv import read_dv

--- a/src/sim_recon/otf_view.py
+++ b/src/sim_recon/otf_view.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 import matplotlib.pyplot as plt
 from typing import TYPE_CHECKING
+import numpy as np
 
 from .progress import get_progress_wrapper, get_logging_redirect
 from .images.dv import read_dv
@@ -123,7 +124,7 @@ def _create_otf_plots(array: NDArray[Any]) -> Figure:
         if i == 0:
             axes[0, i].set_ylabel("Amplitude")
         axes[0, i].imshow(
-            gamma_adjust(array[i, ::-1, :].absolute, 0.3),
+            gamma_adjust(np.absolute(array[i, ::-1, :]), 0.3),
             vmin=-0.1,
             vmax=1,
             cmap="plasma",
@@ -135,7 +136,7 @@ def _create_otf_plots(array: NDArray[Any]) -> Figure:
         if i == 0:
             axes[1, i].set_ylabel("Phase")
         axes[1, i].imshow(
-            gamma_adjust(array[i, ::-1, :].angle, 1),
+            gamma_adjust(np.angle(array[i, ::-1, :]), 1),
             vmin=-0.1,
             vmax=0.1,
             cmap="gray",


### PR DESCRIPTION


Did this at home on my mac so not easy to test it but changed the real and imaginary components to the much more useful amplitude and phase. ie complex numbers as polar. This is more useful as this better describes the imaging process with amplitude and phase shift. 

 Also remapped the phase component to have a gamma of 1 as a linear colour map on phase is much more useful. 
