### PR TITLE
Add `depends_on` option for override settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Overrides:
                         Number of output SIM orders (must be <= nphases//2;
                         safe to ignore usually) (default=0)
   --angle0 ANGLE0       Angle of the first SIM angle in radians
-                        (default=1.648)
+                        (default=1.648) (depends on: k0angles is None)
   --ls LS               Line spacing of SIM pattern in microns (default=0.172)
   --na NA               Detection objective's numerical aperture (default=1.2)
   --nimm NIMM           Refractive index of immersion medium (default=1.33)
@@ -207,25 +207,29 @@ Overrides:
                         Use these pattern vector k0 angles for all directions
                         (instead of inferring the rest angles from angle0)
   --otfRA               Use rotationally averaged OTF, otherwise 3/2D OTF is
-                        used for 3/2D raw data
+                        used for 3/2D raw data (default=0)
   --otfPerAngle         Use one OTF per SIM angle, otherwise one OTF is used
                         for all angles, which is how it's been done
-                        traditionally
+                        traditionally (default=0)
   --fastSI              SIM image is organized in Z->Angle->Phase order,
                         otherwise Angle->Z->Phase image order is assumed
+                        (default=0)
   --k0searchAll K0SEARCHALL
-                        Search for k0 at all time points
+                        Search for k0 at all time points (default=0)
   --norescale NORESCALE
-                        No bleach correction
-  --equalizez           Bleach correction for z
-  --equalizet           Bleach correction for time
+                        No bleach correction (default=0)
+  --equalizez           Bleach correction for z (default=0) (depends on:
+                        norescale != 1)
+  --equalizet           Bleach correction for time (default=0) (depends on:
+                        norescale != 1)
   --dampenOrder0        Dampen order-0 in final assembly; do not use for 2D
                         SIM; good choice for high-background images
+                        (default=0)
   --nosuppress NOSUPPRESS
                         Do not suppress DC singularity in the result (good
                         choice for 2D/TIRF data) (default=0)
   --nokz0               Do not use kz=0 plane of the 0th order in the final
-                        assembly (mostly for debug)
+                        assembly (mostly for debug) (default=0)
   --gammaApo GAMMAAPO   Output apodization gamma; 1.0 means triangular apo;
                         lower value means less dampening of high-resolution
                         info at the trade-off of higher noise (default=1)
@@ -244,19 +248,20 @@ Overrides:
   --saveoverlaps SAVEOVERLAPS
                         Save overlap0 and overlap1 (real-space complex data)
                         into a file and exit (for debug)
-  --2lenses             Toggle to indicate I5S data
-  --bessel              Toggle to indicate Bessel-SIM data
+  --2lenses             Toggle to indicate I5S data (default=0)
+  --bessel              Toggle to indicate Bessel-SIM data (default=0)
   --besselExWave BESSELEXWAVE
                         Bessel SIM excitation wavelength in microns
-                        (default=0.488)
-  --besselNA BESSELNA   Bessel SIM excitation NA (default=0.144)
+                        (default=0.488) (depends on: bessel == 1)
+  --besselNA BESSELNA   Bessel SIM excitation NA (default=0.144) (depends on:
+                        bessel == 1)
   --deskew DESKEW       Deskew angle; if not 0.0 then perform deskewing before
                         processing (default=0)
   --deskewshift DESKEWSHIFT
                         If deskewed, shift the output image by this in X
-                        (positive->left) (default=0)
+                        (positive->left) (default=0) (depends on: deskew != 0)
   --noRecon             No reconstruction will be performed; useful when
-                        combined with "deskew"
+                        combined with "deskew" (default=0)
   --cropXY CROPXY       Crop the X-Y dimension to this number; 0 means no
                         cropping (default=0)
   --xyres XYRES         X-Y pixel size (use metadata value by default)

--- a/docs/help/sim_recon.txt
+++ b/docs/help/sim_recon.txt
@@ -60,7 +60,7 @@ Overrides:
                         Number of output SIM orders (must be <= nphases//2;
                         safe to ignore usually) (default=0)
   --angle0 ANGLE0       Angle of the first SIM angle in radians
-                        (default=1.648)
+                        (default=1.648) (depends on: k0angles is None)
   --ls LS               Line spacing of SIM pattern in microns (default=0.172)
   --na NA               Detection objective's numerical aperture (default=1.2)
   --nimm NIMM           Refractive index of immersion medium (default=1.33)
@@ -84,25 +84,29 @@ Overrides:
                         Use these pattern vector k0 angles for all directions
                         (instead of inferring the rest angles from angle0)
   --otfRA               Use rotationally averaged OTF, otherwise 3/2D OTF is
-                        used for 3/2D raw data
+                        used for 3/2D raw data (default=0)
   --otfPerAngle         Use one OTF per SIM angle, otherwise one OTF is used
                         for all angles, which is how it's been done
-                        traditionally
+                        traditionally (default=0)
   --fastSI              SIM image is organized in Z->Angle->Phase order,
                         otherwise Angle->Z->Phase image order is assumed
+                        (default=0)
   --k0searchAll K0SEARCHALL
-                        Search for k0 at all time points
+                        Search for k0 at all time points (default=0)
   --norescale NORESCALE
-                        No bleach correction
-  --equalizez           Bleach correction for z
-  --equalizet           Bleach correction for time
+                        No bleach correction (default=0)
+  --equalizez           Bleach correction for z (default=0) (depends on:
+                        norescale != 1)
+  --equalizet           Bleach correction for time (default=0) (depends on:
+                        norescale != 1)
   --dampenOrder0        Dampen order-0 in final assembly; do not use for 2D
                         SIM; good choice for high-background images
+                        (default=0)
   --nosuppress NOSUPPRESS
                         Do not suppress DC singularity in the result (good
                         choice for 2D/TIRF data) (default=0)
   --nokz0               Do not use kz=0 plane of the 0th order in the final
-                        assembly (mostly for debug)
+                        assembly (mostly for debug) (default=0)
   --gammaApo GAMMAAPO   Output apodization gamma; 1.0 means triangular apo;
                         lower value means less dampening of high-resolution
                         info at the trade-off of higher noise (default=1)
@@ -121,19 +125,20 @@ Overrides:
   --saveoverlaps SAVEOVERLAPS
                         Save overlap0 and overlap1 (real-space complex data)
                         into a file and exit (for debug)
-  --2lenses             Toggle to indicate I5S data
-  --bessel              Toggle to indicate Bessel-SIM data
+  --2lenses             Toggle to indicate I5S data (default=0)
+  --bessel              Toggle to indicate Bessel-SIM data (default=0)
   --besselExWave BESSELEXWAVE
                         Bessel SIM excitation wavelength in microns
-                        (default=0.488)
-  --besselNA BESSELNA   Bessel SIM excitation NA (default=0.144)
+                        (default=0.488) (depends on: bessel == 1)
+  --besselNA BESSELNA   Bessel SIM excitation NA (default=0.144) (depends on:
+                        bessel == 1)
   --deskew DESKEW       Deskew angle; if not 0.0 then perform deskewing before
                         processing (default=0)
   --deskewshift DESKEWSHIFT
                         If deskewed, shift the output image by this in X
-                        (positive->left) (default=0)
+                        (positive->left) (default=0) (depends on: deskew != 0)
   --noRecon             No reconstruction will be performed; useful when
-                        combined with "deskew"
+                        combined with "deskew" (default=0)
   --cropXY CROPXY       Crop the X-Y dimension to this number; 0 means no
                         cropping (default=0)
   --xyres XYRES         X-Y pixel size (use metadata value by default)

--- a/src/sim_recon/cli/parsing/otf.py
+++ b/src/sim_recon/cli/parsing/otf.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 import argparse
 from typing import TYPE_CHECKING
 
-from ...settings.formatting import OTF_FORMATTERS
+from ...settings.formatting import filter_out_invalid_kwargs, OTF_FORMATTERS
 from .shared import (
     add_general_args,
     add_override_args_from_formatters,
-    namespace_extract_to_dict,
 )
 
 if TYPE_CHECKING:
@@ -71,7 +70,9 @@ def parse_args(
     namespace, _ = parser.parse_known_args(args)
 
     # Split out kwargs to be used in makeotf
-    otf_kwargs = namespace_extract_to_dict(namespace, OTF_FORMATTERS, allow_none=False)
+    otf_kwargs = filter_out_invalid_kwargs(
+        vars(namespace), OTF_FORMATTERS, allow_none=False
+    )
 
     return namespace, otf_kwargs
 

--- a/src/sim_recon/cli/parsing/recon.py
+++ b/src/sim_recon/cli/parsing/recon.py
@@ -3,11 +3,10 @@ import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ...settings.formatting import RECON_FORMATTERS
+from ...settings.formatting import filter_out_invalid_kwargs, RECON_FORMATTERS
 from .shared import (
     add_general_args,
     add_override_args_from_formatters,
-    namespace_extract_to_dict,
 )
 
 if TYPE_CHECKING:
@@ -103,8 +102,8 @@ def parse_args(
     namespace, _ = parser.parse_known_args(args)
 
     # Split out kwargs to be used in recon config(s)
-    recon_kwargs = namespace_extract_to_dict(
-        namespace, RECON_FORMATTERS, allow_none=False
+    recon_kwargs = filter_out_invalid_kwargs(
+        vars(namespace), RECON_FORMATTERS, allow_none=False
     )
 
     return namespace, recon_kwargs

--- a/src/sim_recon/cli/parsing/shared.py
+++ b/src/sim_recon/cli/parsing/shared.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from typing import Any
-    from collections.abc import Container
     from ...settings.formatting import SettingFormat
 
 
@@ -48,12 +46,3 @@ def add_override_args_from_formatters(
                 required=False,
                 help=formatter.help_string,
             )
-
-
-def namespace_extract_to_dict(
-    namespace: argparse.Namespace, args: Container[str], allow_none: bool = True
-) -> dict[str, Any]:
-    key_value_generator = ((k, v) for k, v in vars(namespace).items() if k in args)
-    if allow_none:
-        return dict(key_value_generator)
-    return {k: v for k, v in key_value_generator if v is not None}

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -20,7 +20,11 @@ from .images.dv import write_dv
 from .images.tiff import read_tiff, write_tiff, get_combined_array_from_tiffs
 from .images.dataclasses import ImageChannel, Wavelengths, ProcessingInfo
 from .settings import ConfigManager
-from .settings.formatting import formatters_to_default_value_kwargs, RECON_FORMATTERS
+from .settings.formatting import (
+    formatters_to_default_value_kwargs,
+    filter_out_invalid_kwargs,
+    RECON_FORMATTERS,
+)
 from .progress import get_progress_wrapper, get_logging_redirect
 from .exceptions import (
     PySimReconFileNotFoundError,
@@ -363,6 +367,8 @@ def _prepare_config_kwargs(
 
     # config_kwargs override those any config defaults set
     kwargs.update(config_kwargs)
+
+    kwargs = filter_out_invalid_kwargs(kwargs, RECON_FORMATTERS, allow_none=False)
 
     # Set final variables:
     kwargs["wavelength"] = emission_wavelength

--- a/src/sim_recon/settings/formatting.py
+++ b/src/sim_recon/settings/formatting.py
@@ -46,6 +46,7 @@ class SettingFormat:
     nargs: int | Literal["+"] = 1  # "+" matching argparse
     description: str | None = None
     default_value: Any = None
+    depends_on: tuple[str, ...] | None = None
 
     @property
     def help_string(self) -> str | None:
@@ -54,6 +55,8 @@ class SettingFormat:
             help_string_parts.append(self.description)
         if self.default_value is not None:
             help_string_parts.append(f"(default={self.default_value})")
+        if self.depends_on is not None:
+            help_string_parts.append((f"(depends on: {', '.join(self.depends_on)})"))
         if help_string_parts:
             return " ".join(help_string_parts)
         return None
@@ -288,11 +291,13 @@ RECON_FORMATTERS: dict[str, SettingFormat] = {
         SettingConverters.FLOAT,
         description="Bessel SIM excitation wavelength in microns",
         default_value=Decimal("0.488"),
+        depends_on=("bessel",),
     ),
     "besselNA": SettingFormat(
         SettingConverters.FLOAT,
         description="Bessel SIM excitation NA",
         default_value=Decimal("0.144"),
+        depends_on=("bessel",),
     ),
     "deskew": SettingFormat(
         SettingConverters.FLOAT,
@@ -303,6 +308,7 @@ RECON_FORMATTERS: dict[str, SettingFormat] = {
         SettingConverters.INT_POSITIVE,
         description="If deskewed, shift the output image by this in X (positive->left)",
         default_value=0,
+        depends_on=("deskew",),
     ),
     "noRecon": SettingFormat(
         SettingConverters.INT_FROM_BOOL,

--- a/src/sim_recon/settings/formatting.py
+++ b/src/sim_recon/settings/formatting.py
@@ -349,6 +349,28 @@ RECON_FORMATTERS: dict[str, SettingFormat] = {
 }
 
 
+def filter_out_invalid_kwargs(
+    kwargs: dict[str, Any],
+    formatters: dict[str, SettingFormat],
+    allow_none: bool = True,
+) -> dict[str, Any]:
+    output_kwargs = kwargs.copy()
+    for arg_name, value in kwargs.items():
+        setting_format = formatters.get(arg_name)
+        if (
+            (not allow_none and value is None)  # Check for None values
+            or setting_format is None  # Check setting is in formatters
+            or (
+                # Check if any dependencies are unmet
+                setting_format.depends_on is not None
+                and any(dep not in output_kwargs for dep in setting_format.depends_on)
+            )
+        ):
+            del output_kwargs[arg_name]
+
+    return output_kwargs
+
+
 def formatters_to_default_value_kwargs(
     formatters: dict[str, SettingFormat]
 ) -> dict[str, Any]:


### PR DESCRIPTION
It is confusing explicitly stating all settings when some settings aren't valid due to their dependency on others. By adding a `depends_on` option to `SettingFormat`, this can be handled better.

Closes #42