### PR TITLE
Make optional tqdm dependency clearer

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -5,4 +5,3 @@ pycudasirecon >= 0.1.0
 mrc >= 0.3.1
 numpy < 2
 tifffile >= 2024.2.12
-tqdm

--- a/docs/sections/installation.md
+++ b/docs/sections/installation.md
@@ -17,6 +17,8 @@ This is not yet published on conda-forge, so the installation process is fairly 
 2. Clone (or download) this repository.
 3. Navigate to where you've cloned the repo within your terminal.
 4. Install the requirements from the conda_requirements.txt file `conda install -c conda-forge --file conda_requirements.txt`. If there are any issues with this step, please refer to the [requirements](#requirements) section.
-5. Install the package with pip, now that the requirements have been met `python -m pip install .` The argument `-e` can be added if you want it install it in editable mode.
+5. Install the package with pip, now that the requirements have been met:
+   * It is recommended to install the package using `python -m pip install .[progress]` as this includes progress bars using [tqdm](https://tqdm.github.io/) (simply use `python -m pip install .` if you don't want this).
+   * The package can be installed in editable mode by adding the option `-e`, i.e. `python -m pip install -e .[progress]`.
 
 If you have any problems installing this package, please open an issue.


### PR DESCRIPTION
- Removes tqdm from conda_requirements.txt
- Adds instructions about installing progress bars:
  - How to install 'progress' feature via pip
  - Clearly states it is an optional feature
  - Links to tqdm