### PR TITLE
Generate docs only on changes to 'main' branch

### DIFF
--- a/.github/workflows/generate_README.yaml
+++ b/.github/workflows/generate_README.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Fill template
         run: |
           ./releng/README_from_docs.sh
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: README.md

--- a/.github/workflows/generate_README.yaml
+++ b/.github/workflows/generate_README.yaml
@@ -1,5 +1,10 @@
 name: Generate README
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      git_ref:
+        description: "Git reference to use for checks"
+        type: string
 
 jobs:
   make-README:
@@ -9,7 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ inputs.git_ref }}
+          sparse-checkout: |
+            README.md
+            docs
+            releng
+
       - name: Fill template
         run: |
           ./releng/README_from_docs.sh

--- a/.github/workflows/generate_README.yaml
+++ b/.github/workflows/generate_README.yaml
@@ -5,6 +5,10 @@ on:
       git_ref:
         description: "Git reference to use for checks"
         type: string
+      push_options:
+        description: "push_options passed to stefanzweifel/git-auto-commit-action"
+        type: string
+        default: ""
 
 jobs:
   make-README:
@@ -27,4 +31,5 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: README.md
-          commit_message: Automated update of README.md from docs
+          commit_message: Update README.md from docs [GitHub Action]
+          push_options: ${{ inputs.push_options }}

--- a/.github/workflows/generate_help_docs.yaml
+++ b/.github/workflows/generate_help_docs.yaml
@@ -5,6 +5,7 @@ on:
       git_ref:
         description: "Git reference to use for checks"
         type: string
+
     outputs:
       help_docs_changed:
         description: "'true' if the help docs were updated, otherwise 'false'"
@@ -21,25 +22,32 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git_ref }}
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
+
       - name: Copy template
         run: cp -f docs/template.md README.md
+
       - name: Install (without dependencies)
         run: |
           python -m pip install --upgrade pip
           python -m pip install . --no-deps
+
       - name: Ensure README exists
         run: |
           if [ ! -f "README.md" ]; then
             touch README.md
           fi
+
       - name: Generate help docs from package
         run: ./releng/generate_help_docs.sh
+
       - uses: stefanzweifel/git-auto-commit-action@v5
         id: autocommit
         with:

--- a/.github/workflows/generate_help_docs.yaml
+++ b/.github/workflows/generate_help_docs.yaml
@@ -1,11 +1,18 @@
 name: Generate help docs
-on: workflow_call
+on:
+  workflow_call:
+    outputs:
+      help_docs_changed:
+        description: "'true' if the help docs were updated, otherwise 'false'"
+        value: ${{ jobs.generate-help-docs.outputs.help_docs_changed }}
 
 jobs:
   generate-help-docs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      help_docs_changed: ${{ steps.autocommit.outputs.changes_detected }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,6 +37,7 @@ jobs:
       - name: Generate help docs from package
         run: ./releng/generate_help_docs.sh
       - uses: stefanzweifel/git-auto-commit-action@v5
+        id: autocommit
         with:
           file_pattern: docs/**/*
           commit_message: Automated update of help docs

--- a/.github/workflows/generate_help_docs.yaml
+++ b/.github/workflows/generate_help_docs.yaml
@@ -1,6 +1,10 @@
 name: Generate help docs
 on:
   workflow_call:
+    inputs:
+      git_ref:
+        description: "Git reference to use for checks"
+        type: string
     outputs:
       help_docs_changed:
         description: "'true' if the help docs were updated, otherwise 'false'"
@@ -16,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ inputs.git_ref }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/generate_help_docs.yaml
+++ b/.github/workflows/generate_help_docs.yaml
@@ -5,6 +5,10 @@ on:
       git_ref:
         description: "Git reference to use for checks"
         type: string
+      push_options:
+        description: "push_options passed to stefanzweifel/git-auto-commit-action"
+        type: string
+        default: ""
 
     outputs:
       help_docs_changed:
@@ -52,4 +56,5 @@ jobs:
         id: autocommit
         with:
           file_pattern: docs/**/*
-          commit_message: Automated update of help docs
+          commit_message: Update help docs [GitHub Action]
+          push_options: ${{ inputs.push_options }}

--- a/.github/workflows/trigger_docs_generation.yaml
+++ b/.github/workflows/trigger_docs_generation.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -24,12 +25,14 @@ jobs:
             parser:
               - 'src/sim_recon/cli/parsing/*'
               - 'src/sim_recon/settings/formatting.py'
+
   generate-help-docs:
     needs: check-changes
     if: needs.check-changes.outputs.parser-changed == 'true'
     uses: ./.github/workflows/generate_help_docs.yaml
     with:
       git_ref: ${{ github.head_ref }}
+
   generate-README:
     needs: [check-changes, generate-help-docs]
     if: always() && !cancelled() && (needs.check-changes.outputs.docs-changed == 'true' || needs.generate-help-docs.outputs.help_docs_changed == 'true')

--- a/.github/workflows/trigger_docs_generation.yaml
+++ b/.github/workflows/trigger_docs_generation.yaml
@@ -1,5 +1,8 @@
 name: Trigger docs generation
-on: pull_request
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   check-changes:
@@ -10,12 +13,14 @@ jobs:
       parser-changed: ${{ steps.filter.outputs.parser }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             docs:
-              - 'docs/**/*'
+              - 'docs/**'
             parser:
               - 'src/sim_recon/cli/parsing/*'
               - 'src/sim_recon/settings/formatting.py'
@@ -23,7 +28,11 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.parser-changed == 'true'
     uses: ./.github/workflows/generate_help_docs.yaml
+    with:
+      git_ref: ${{ github.head_ref }}
   generate-README:
     needs: [check-changes, generate-help-docs]
     if: always() && !cancelled() && (needs.check-changes.outputs.docs-changed == 'true' || needs.generate-help-docs.outputs.help_docs_changed == 'true')
     uses: ./.github/workflows/generate_README.yaml
+    with:
+      git_ref: ${{ github.head_ref }}

--- a/.github/workflows/trigger_docs_generation.yaml
+++ b/.github/workflows/trigger_docs_generation.yaml
@@ -2,42 +2,28 @@ name: Trigger docs generation
 on: pull_request
 
 jobs:
-  check-parser-paths:
+  check-changes:
+    # Check changes against the most recent commit on the same branch before the push
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.filter.outputs.parser }}
+      docs-changed: ${{ steps.filter.outputs.docs }}
+      parser-changed: ${{ steps.filter.outputs.parser }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            parser:
-              - 'src/sim_recon/cli/parsing/*'
-              - 'src/sim_recon/settings/formatting.py'
-  generate-help-docs:
-    needs: check-parser-paths
-    if: needs.check-parser-paths.outputs.changed == 'true'
-    uses: ./.github/workflows/generate_help_docs.yaml
-  check-docs-paths: # Checking this after generate-help-docs ensures changes made by that workflow are found
-    runs-on: ubuntu-latest
-    needs: generate-help-docs
-    if: always() && !cancelled() # Should be run after generate-help-docs, regardless of the result
-    outputs:
-      changed: ${{ steps.filter.outputs.docs }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             docs:
               - 'docs/**/*'
+            parser:
+              - 'src/sim_recon/cli/parsing/*'
+              - 'src/sim_recon/settings/formatting.py'
+  generate-help-docs:
+    needs: check-changes
+    if: needs.check-changes.outputs.parser-changed == 'true'
+    uses: ./.github/workflows/generate_help_docs.yaml
   generate-README:
-    needs: check-docs-paths
-    if: always() && !cancelled() && needs.check-docs-paths.outputs.changed == 'true'
+    needs: [check-changes, generate-help-docs]
+    if: always() && !cancelled() && (needs.check-changes.outputs.docs-changed == 'true' || needs.generate-help-docs.outputs.help_docs_changed == 'true')
     uses: ./.github/workflows/generate_README.yaml


### PR DESCRIPTION
I've tested this out with another branch and it runs well. This way, it won't hold up PRs or have issues with "Rebase and merge". These were failing to run on PRs from Ian, so this should work around this issue.

Example workflow runs:
No changes in relevant areas (no updates): https://github.com/DiamondLightSource/PySIMRecon/actions/runs/11038344305
Added text to a parser description (runs both workflows in order): https://github.com/DiamondLightSource/PySIMRecon/actions/runs/11038355719
Added text to template.md (runs only README update): https://github.com/DiamondLightSource/PySIMRecon/actions/runs/11038373033

The only thing is it might require is a force push, depending on the branch protections. I am unable to see the branch settings on this repo, so I'm not sure if this will be able to push changes.