### PR TITLE
Improve exception handling

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,54 @@
+class PySimReconException(Exception):
+    pass
+
+
+class PySimReconOSError(OSError, PySimReconException):
+    pass
+
+
+class PySimReconTypeError(TypeError, PySimReconException):
+    pass
+
+
+class PySimReconValueError(ValueError, PySimReconException):
+    pass
+
+
+class PySimReconFileExistsError(FileExistsError, PySimReconException):
+    pass
+
+
+class PySimReconFileNotFoundError(FileNotFoundError, PySimReconException):
+    pass
+
+
+class PySimReconIOError(IOError, PySimReconException):
+    pass
+
+
+class ProcessingException(PySimReconException):
+    pass
+
+
+class OtfError(ProcessingException):
+    pass
+
+
+class ReconstructionError(ProcessingException):
+    pass
+
+
+class ConfigException(PySimReconException):
+    pass
+
+
+class UndefinedValueError(PySimReconValueError):
+    pass
+
+
+class InvalidValueError(PySimReconValueError):
+    pass
+
+
+class MissingOtfException(ConfigException):
+    pass

--- a/src/sim_recon/cli/dv_to_tiff.py
+++ b/src/sim_recon/cli/dv_to_tiff.py
@@ -15,6 +15,8 @@ def main() -> None:
             if not fp.is_file():
                 raise PySimReconFileNotFoundError(f"{fp} is not a file")
             dv_to_tiff(fp, fp.with_suffix(".tiff"))
+        except PySimReconFileNotFoundError:
+            _logger.error("File not found", exc_info=True)
         except Exception:
             _logger.error("Failed to process %s", arg, exc_info=True)
 

--- a/src/sim_recon/cli/dv_to_tiff.py
+++ b/src/sim_recon/cli/dv_to_tiff.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 from ..images import dv_to_tiff
+from ...exceptions import PySimReconFileNotFoundError
 
 _logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ def main() -> None:
         try:
             fp = Path(arg)
             if not fp.is_file():
-                raise FileNotFoundError(f"{fp} is not a file")
+                raise PySimReconFileNotFoundError(f"{fp} is not a file")
             dv_to_tiff(fp, fp.with_suffix(".tiff"))
         except Exception:
             _logger.error("Failed to process %s", arg, exc_info=True)

--- a/src/sim_recon/files/config.py
+++ b/src/sim_recon/files/config.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from ..settings import ChannelConfig
 from ..settings.formatting import OTF_FORMATTERS, RECON_FORMATTERS
+from ...exceptions import PySimReconFileNotFoundError, PySimReconTypeError
 
 if TYPE_CHECKING:
     from typing import Literal, Any, TypeVar
@@ -50,7 +51,7 @@ def _handle_paths_from_config(
 
     # If directory is not specified, an absolute path is required
     if not path.is_file():
-        raise FileNotFoundError(f"No {key} file found for at {path}")
+        raise PySimReconFileNotFoundError(f"No {key} file found for at {path}")
     # Ensure returned path is absolute
     return key, path.absolute()
 
@@ -178,7 +179,7 @@ def _config_section_to_dict(
     elif settings_for == "recon":
         formatters = RECON_FORMATTERS
     else:
-        raise TypeError(
+        raise PySimReconTypeError(
             '_config_section_to_dict argument "settings_for" only accepts "otf" or "recon"'
         )
 

--- a/src/sim_recon/files/utils.py
+++ b/src/sim_recon/files/utils.py
@@ -10,6 +10,13 @@ from uuid import uuid4
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
+from ...exceptions import (
+    PySimReconFileExistsError,
+    PySimReconIOError,
+    PySimReconOSError,
+    PySimReconValueError,
+)
+
 if TYPE_CHECKING:
     from typing import Literal
     from os import PathLike
@@ -31,7 +38,7 @@ def get_temporary_path(directory: Path, stem: str, suffix: str) -> Path:
     tiff_path = (directory / f"{stem}_{uuid4()}").with_suffix(suffix)
     if not tiff_path.exists():
         return tiff_path
-    raise FileExistsError(
+    raise PySimReconFileExistsError(
         f"Failed to create temporary file as the following already exists: {tiff_path}"
     )
 
@@ -40,7 +47,7 @@ def ensure_unique_filepath(path: Path, max_iter: int = 99) -> Path:
     if not path.exists():
         return path
     if max_iter <= 1:
-        raise ValueError("max_iter must be >1")
+        raise PySimReconValueError("max_iter must be >1")
     output_path = None
     for i in range(1, max_iter + 1):
         output_path = path.with_name(f"{path.stem}_{i}{path.suffix}")
@@ -50,7 +57,7 @@ def ensure_unique_filepath(path: Path, max_iter: int = 99) -> Path:
     error_str = f"Failed to create unique file path after {max_iter} attempts."
     if output_path is not None:
         error_str += f" Final attempt was '{output_path}'."
-    raise IOError(error_str)
+    raise PySimReconIOError(error_str)
 
 
 def ensure_valid_filename(filename: str) -> str:
@@ -64,7 +71,7 @@ def ensure_valid_filename(filename: str) -> str:
     elif system == "Darwin":
         invalid_chars = _DARWIN_FN_SUB
     else:
-        raise OSError(f"{system} is not a supported system")
+        raise PySimReconOSError(f"{system} is not a supported system")
 
     new_filename = filename.rstrip(rstrip)
     new_filename = re.sub(invalid_chars, "_", new_filename)

--- a/src/sim_recon/images/tiff.py
+++ b/src/sim_recon/images/tiff.py
@@ -7,6 +7,7 @@ import tifffile as tf
 from typing import TYPE_CHECKING, cast
 
 from ..info import __version__
+from ...exceptions import PySimReconFileExistsError
 
 if TYPE_CHECKING:
     from typing import Any
@@ -61,7 +62,7 @@ def write_tiff(
             logger.warning("Overwriting file %s", output_path)
             output_path.unlink()
         else:
-            raise FileExistsError(f"File {output_path} already exists")
+            raise PySimReconFileExistsError(f"File {output_path} already exists")
 
     tiff_kwargs: dict[str, Any] = {
         "software": f"PySIMRecon {__version__}",

--- a/src/sim_recon/otf_view.py
+++ b/src/sim_recon/otf_view.py
@@ -9,6 +9,7 @@ from .progress import get_progress_wrapper, get_logging_redirect
 from .images.dv import read_dv
 from .images.tiff import read_tiff
 from .images.utils import interleaved_float_to_complex
+from ..exceptions import PySimReconIOError
 
 if TYPE_CHECKING:
     from typing import Any
@@ -74,7 +75,7 @@ def _open_otf(file_path: str | PathLike[str]) -> NDArray[Any]:
         return read_dv(file_path).asarray(squeeze=True)
     except Exception:
         pass
-    raise IOError(f"Unable to read {file_path}")
+    raise PySimReconIOError(f"Unable to read {file_path}")
 
 
 def _create_otf_plots(array: NDArray[Any]) -> Figure:

--- a/src/sim_recon/settings/dataclasses.py
+++ b/src/sim_recon/settings/dataclasses.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field, InitVar
 from typing import TYPE_CHECKING
 
+from ...exceptions import UndefinedValueError
+
 
 if TYPE_CHECKING:
     from typing import Any
@@ -74,5 +76,7 @@ class ConfigManager:
     def get_otf_path(self, emission_wavelength_nm: int) -> Path | None:
         ws = self.get_channel_config(emission_wavelength_nm)
         if ws is None:
-            raise ValueError(f"Channel '{emission_wavelength_nm}' is not configured")
+            raise UndefinedValueError(
+                f"Channel '{emission_wavelength_nm}' is not configured"
+            )
         return ws.otf


### PR DESCRIPTION
As seen in #53, some of the errors aren't particularly clear. The changes in 215744000310c55fe7b5300121512f293094ce43 should fix that.

I also made custom exceptions to ensure exceptions from PySIMRecon can be caught with `except PySimReconException`, though perhaps this is not necessary.