### PR TITLE
Improve parser help

### DIFF
--- a/src/sim_recon/cli/parsing/otf.py
+++ b/src/sim_recon/cli/parsing/otf.py
@@ -40,7 +40,7 @@ def parse_args(
     parser.add_argument(
         "-o",
         "--output-directory",
-        help="If specified, the output directory that the OTFs will be saved in, otherwise each OTF will be saved in the same directory as its PSF",
+        help="If specified, the output directory in which the OTF files will be saved (otherwise each OTF will be saved in the same directory as its PSF)",
     )
     parser.add_argument(
         "--overwrite",

--- a/src/sim_recon/cli/parsing/recon.py
+++ b/src/sim_recon/cli/parsing/recon.py
@@ -65,10 +65,10 @@ def parse_args(
         dest="otfs",
         type=_otf_arg_conv,
         action="append",
-        help="OTF file for a channel, which should be specified using the "
-        "emission wavelength in nm followed by the path to the OTF file e.g. "
-        "'--otf 525 /path/to/525_otf.tiff' (argument can be given multiple "
-        "times to provide OTFs for multiple channels)",
+        help="The OTF file for a channel can be specified, which should be "
+        "given as <emission wavelength in nm>:<the path to the OTF file> "
+        "e.g. '--otf 525:/path/to/525_otf.tiff' (argument can be given "
+        "multiple times to provide OTFs for multiple channels)",
     )
     parser.add_argument(
         "-amc",

--- a/src/sim_recon/cli/parsing/recon.py
+++ b/src/sim_recon/cli/parsing/recon.py
@@ -58,7 +58,7 @@ def parse_args(
     parser.add_argument(
         "-o",
         "--output-directory",
-        help="The output directory to save reconstructed files in",
+        help="If specified, the output directory in which the reconstructed files will be saved (otherwise each reconstruction will be saved in the same directory as its SIM data file)",
     )
     parser.add_argument(
         "--otf",


### PR DESCRIPTION
- The `--output-directory` wasn't written consistently for `sim-recon` and `sim-otf`
- `--otfs` didn't have the correct separator listed and could be made clearer