### PR TITLE
Ensure README is updated after generating new help docs

### DIFF
--- a/.github/workflows/generate_README.yaml
+++ b/.github/workflows/generate_README.yaml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   make-README:
+    concurrency:
+      group: make-README -- ${{ github.workflow }} -- ${{ github.ref_name }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/generate_help_docs.yaml
+++ b/.github/workflows/generate_help_docs.yaml
@@ -17,6 +17,9 @@ on:
 
 jobs:
   generate-help-docs:
+    concurrency:
+      group: generate-help-docs -- ${{ github.workflow }} -- ${{ github.ref_name }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/trigger_docs_generation.yaml
+++ b/.github/workflows/trigger_docs_generation.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: ${{ github.ref_name }}
           filters: |
             docs:
               - 'docs/**'
@@ -31,11 +32,11 @@ jobs:
     if: needs.check-changes.outputs.parser-changed == 'true'
     uses: ./.github/workflows/generate_help_docs.yaml
     with:
-      git_ref: ${{ github.head_ref }}
+      git_ref: ${{ github.ref_name }}
 
   generate-README:
     needs: [check-changes, generate-help-docs]
     if: always() && !cancelled() && (needs.check-changes.outputs.docs-changed == 'true' || needs.generate-help-docs.outputs.help_docs_changed == 'true')
     uses: ./.github/workflows/generate_README.yaml
     with:
-      git_ref: ${{ github.head_ref }}
+      git_ref: ${{ github.ref_name }}


### PR DESCRIPTION


As can be seen in workflow run A, no changes were made to the README after updating the help docs.

These changes are working, as evidenced in workflow run B. The concurrency check added as a way to ensure that there aren't clashes with commits in quick succession, now that it's using `github.ref_name` (branch reference) rather than using `github.head_ref`, which is the HEAD ref commit from when the workflow was triggered.

An example of one job stopping another can be seen in workflow run C, which was started after run B I gave. However, the generate-README job from workflow run C was started before the generate-README job in workflow run B, so that job from workflow run C was cancelled by the one from workflow run B, as that would have the most up to date version of the docs.

Workflow run A:
https://github.com/DiamondLightSource/PySIMRecon/actions/runs/11122104546

Workflow run B:
https://github.com/DiamondLightSource/PySIMRecon/actions/runs/11150061754

Workflow run C:
https://github.com/DiamondLightSource/PySIMRecon/actions/runs/11150064786