### PR TITLE
remove non-Python dependency of cudasirecon from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
     { name = "Thomas Fish", email = "thomas.fish@diamond.ac.uk" },
 ]
 dependencies = [
-    "cudasirecon >= 1.2.0",
     "pycudasirecon ~= 0.1.0",
     "numpy ~= 1.26.4",
     "matplotlib ~= 3.9.2",


### PR DESCRIPTION
PySIMRecon will always fail to install as it cannot find Python cannot find cudasirecon (since it is not a Python package!)