### PR TITLE
Improve naming of proc files

### DIFF
--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -509,7 +509,7 @@ def _prepare_files(
                 )
 
             split_file_path = (
-                processing_dir / f"data{channel.wavelengths.emission_nm}.tiff"
+                processing_dir / f"data{channel.wavelengths.emission_nm_int}.tiff"
             )
             write_tiff(
                 split_file_path,

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -462,7 +462,6 @@ def create_processing_info(
         output_type="recon",
         suffix=".tiff",
         output_directory=output_dir,
-        wavelength=wavelengths.emission_nm_int,
         ensure_unique=True,
     )
     return ProcessingInfo(


### PR DESCRIPTION
Log files in the proc directories were being called `data603.0_recon_603.log`, which is a mess. This is changed to `data603_recon.log` by:
- Using the integer channel name instead of the float when naming the data file (was `data603.0.tiff`, now `data603.tiff`)
- Not adding the wavelength again when creating the log file name 