### PR TITLE
Enable saving reconstruction outputs as TIFF

### DIFF
--- a/src/sim_recon/cli/parsing/recon.py
+++ b/src/sim_recon/cli/parsing/recon.py
@@ -78,6 +78,13 @@ def parse_args(
         help="If specified, attempt reconstruction of other channels in a multi-channel file if one or more are not configured",
     )
     parser.add_argument(
+        "--type",
+        dest="output_file_type",
+        choices=["dv", "tiff"],
+        default="dv",
+        help="File type of output images",
+    )
+    parser.add_argument(
         "--overwrite",
         action="store_true",
         help="If specified, files will be overwritten if they already exist (unique filenames will be used otherwise)",

--- a/src/sim_recon/cli/recon.py
+++ b/src/sim_recon/cli/recon.py
@@ -22,6 +22,7 @@ def main() -> None:
         stitch_channels=namespace.stitch_channels,
         parallel_process=namespace.parallel_process,
         allow_missing_channels=namespace.allow_missing_channels,
+        output_file_type=namespace.output_file_type,
         **recon_kwargs,
     )
 

--- a/src/sim_recon/files/utils.py
+++ b/src/sim_recon/files/utils.py
@@ -43,14 +43,17 @@ def get_temporary_path(directory: Path, stem: str, suffix: str) -> Path:
     )
 
 
-def ensure_unique_filepath(path: Path, max_iter: int = 99) -> Path:
+def ensure_unique_filepath(
+    output_directory: Path, stem: str, suffix: str, max_iter: int = 99
+) -> Path:
+    path = output_directory / f"{stem}{suffix}"
     if not path.exists():
         return path
     if max_iter <= 1:
         raise PySimReconValueError("max_iter must be >1")
     output_path = None
     for i in range(1, max_iter + 1):
-        output_path = path.with_name(f"{path.stem}_{i}{path.suffix}")
+        output_path = output_directory / f"{stem}_{i}{suffix}"
         if not output_path.exists():
             logger.debug("'%s' was not unique, so '%s' will be used", path, output_path)
             return output_path
@@ -115,11 +118,12 @@ def create_output_path(
         output_directory = Path(output_directory)
 
     file_stem = "_".join(output_fp_parts)
-    output_path = output_directory / ensure_valid_filename(f"{file_stem}{suffix}")
 
     if ensure_unique:
-        output_path = ensure_unique_filepath(output_path, max_iter=max_path_iter)
-    return output_path
+        return ensure_unique_filepath(
+            output_directory, stem=file_stem, suffix=suffix, max_iter=max_path_iter
+        )
+    return output_directory / ensure_valid_filename(f"{file_stem}{suffix}")
 
 
 @contextmanager

--- a/src/sim_recon/images/__init__.py
+++ b/src/sim_recon/images/__init__.py
@@ -59,7 +59,7 @@ def dv_to_tiff(
     write_tiff(
         tiff_path,
         *image_data.channels,
-        xy_pixel_size_microns=(image_data.resolution.x, image_data.resolution.y),
+        resolution=image_data.resolution,
         overwrite=overwrite,
     )
     return Path(tiff_path)

--- a/src/sim_recon/images/__init__.py
+++ b/src/sim_recon/images/__init__.py
@@ -58,8 +58,9 @@ def dv_to_tiff(
                 channel.array = complex_to_interleaved_float(channel.array)
     write_tiff(
         tiff_path,
-        *image_data.channels,
+        image_data.channels,
         resolution=image_data.resolution,
         overwrite=overwrite,
+        allow_missing_channel_info=True,
     )
     return Path(tiff_path)

--- a/src/sim_recon/images/dataclasses.py
+++ b/src/sim_recon/images/dataclasses.py
@@ -50,14 +50,14 @@ class ImageData:
 @dataclass(slots=True)
 class ImageChannel(Generic[OptionalWavelengths]):
     wavelengths: OptionalWavelengths
-    array: NDArray[Any] | None = None
+    array: NDArray[Any]
 
 
 @dataclass(slots=True, frozen=True)
 class ImageResolution:
     x: float
     y: float
-    z: float
+    z: float | None = None
 
 
 @dataclass(slots=True, frozen=True)

--- a/src/sim_recon/images/dv.py
+++ b/src/sim_recon/images/dv.py
@@ -149,7 +149,7 @@ def get_wavelengths_from_dv(dv: mrc.Mrc) -> Generator[Wavelengths, None, None]:
 
 def write_dv(
     output_file: str | PathLike[str],
-    *channels: ImageChannel[Wavelengths],
+    channels: Collection[ImageChannel[Wavelengths]],
     input_dv: mrc.Mrc,
     resolution: ImageResolution,
     overwrite: bool = False,

--- a/src/sim_recon/images/tiff.py
+++ b/src/sim_recon/images/tiff.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+import numpy as np
 import tifffile as tf
 from typing import TYPE_CHECKING
 
@@ -14,7 +15,8 @@ from ..exceptions import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Generator
+    from typing import Any
+    from collections.abc import Generator, Collection
     from os import PathLike
     from numpy.typing import NDArray
     from .dataclasses import Wavelengths
@@ -57,23 +59,46 @@ def generate_channels_from_tiffs(
 
 def write_tiff(
     output_path: str | PathLike[str],
-    *channels: ImageChannel,
+    *images: Collection[ImageChannel[Wavelengths] | ImageChannel[None]],
     resolution: ImageResolution | None = None,
     ome: bool = True,
     allow_empty_channels: bool = False,
+    allow_missing_channel_info: bool = False,
     overwrite: bool = False,
 ) -> Path:
-    def get_channel_dict(channel: ImageChannel) -> dict[str, Any] | None:
-        channel_dict: dict[str, Any] = {}
-        if channel.wavelengths is None:
-            return None
-        if channel.wavelengths.excitation_nm is not None:
-            channel_dict["ExcitationWavelength"] = channel.wavelengths.excitation_nm
-            channel_dict["ExcitationWavelengthUnits"] = "nm"
-        if channel.wavelengths.emission_nm is not None:
-            channel_dict["EmissionWavelength"] = channel.wavelengths.emission_nm
-            channel_dict["EmissionWavelengthUnits"] = "nm"
-        return channel_dict
+    def get_ome_channel_dict(*channels: ImageChannel) -> dict[str, Any] | None:
+        names: list[str] = []
+        excitation_wavelengths: list[float | None] = []
+        excitation_wavelength_units: list[str | None] = []
+        emission_wavelengths: list[float | None] = []
+        emission_wavelength_units: list[str | None] = []
+        for i, channel in enumerate(channels, 1):
+            if channel.wavelengths is None:
+                if not allow_missing_channel_info:
+                    raise UndefinedValueError(f"Missing wavelengths for channel {i}")
+                names.append(f"Channel {i}")
+                excitation_wavelengths.append(None)
+                excitation_wavelength_units.append(None)
+                emission_wavelengths.append(None)
+                emission_wavelength_units.append(None)
+
+            else:
+                names.append(
+                    f"Channel {i}"
+                    if channel.wavelengths.emission_nm_int is None
+                    else str(channel.wavelengths.emission_nm_int)
+                )
+                excitation_wavelengths.append(channel.wavelengths.excitation_nm)
+                excitation_wavelength_units.append("nm")
+                emission_wavelengths.append(channel.wavelengths.emission_nm)
+                emission_wavelength_units.append("nm")
+        return {
+            "Name": names,
+            "ExcitationWavelength": excitation_wavelengths,
+            "ExcitationWavelengthUnits": excitation_wavelength_units,
+            "EmissionWavelength": emission_wavelengths,
+            "EmissionWavelengthUnits": emission_wavelength_units,
+        }
 
     output_path = Path(output_path)
 
@@ -86,10 +111,11 @@ def write_tiff(
         else:
             raise PySimReconFileExistsError(f"File {output_path} already exists")
 
+    tiff_metadata: dict[str, Any] = {}
     tiff_kwargs: dict[str, Any] = {
         "software": f"PySIMRecon {__version__}",
         "photometric": "MINISBLACK",
-        "metadata": {},
+        "metadata": tiff_metadata,
     }
 
     if resolution is not None:
@@ -103,15 +129,16 @@ def write_tiff(
         )  # Use CENTIMETER for maximum compatibility
 
     if ome:
+        tiff_metadata["Name"] = output_path.name
         if resolution is not None:
             # OME PhysicalSize:
-            tiff_kwargs["metadata"]["PhysicalSizeX"] = resolution.x
-            tiff_kwargs["metadata"]["PhysicalSizeXUnit"] = "µm"
-            tiff_kwargs["metadata"]["PhysicalSizeY"] = resolution.x
-            tiff_kwargs["metadata"]["PhysicalSizeYUnit"] = "µm"
+            tiff_metadata["PhysicalSizeX"] = resolution.x
+            tiff_metadata["PhysicalSizeXUnit"] = "µm"
+            tiff_metadata["PhysicalSizeY"] = resolution.x
+            tiff_metadata["PhysicalSizeYUnit"] = "µm"
             if resolution.z is not None:
-                tiff_kwargs["metadata"]["PhysicalSizeZ"] = resolution.z
-                tiff_kwargs["metadata"]["PhysicalSizeYUnit"] = "µm"
+                tiff_metadata["PhysicalSizeZ"] = resolution.z
+                tiff_metadata["PhysicalSizeYUnit"] = "µm"
 
     with tf.TiffWriter(
         output_path,
@@ -120,24 +147,43 @@ def write_tiff(
         ome=ome,
         shaped=not ome,
     ) as tiff:
-        for channel in channels:
-            if channel.array is None:
-                if allow_empty_channels:
-                    logger.warning(
-                        "Channel %s has no array to write",
-                        channel.wavelengths,
+        for channels in images:
+            channels_to_write = []
+            for channel in channels:
+                if channel.array is None:
+                    if allow_empty_channels:
+                        logger.warning(
+                            "Channel %s has no array to write",
+                            channel.wavelengths,
+                        )
+                        continue
+                    raise UndefinedValueError(
+                        f"{output_path} will not be created as channel {channel.wavelengths} has no array to write",
                     )
-                    continue
-                raise UndefinedValueError(
-                    f"{output_path} will not be created as channel {channel.wavelengths} has no array to write",
-                )
-            channel_kwargs = tiff_kwargs.copy()
-            channel_kwargs["metadata"]["axes"] = (
-                "YX" if channel.array.ndim == 2 else "ZYX"
-            )
+                channels_to_write.append(channel)
+
+            array = np.stack(
+                [_.array for _ in channels], axis=0
+            )  # adds another axis, even if only 1 channel
+
+            image_kwargs = tiff_kwargs.copy()
+            if array.ndim == 3:
+                # In case the images are 2D
+                tiff_metadata["axes"] = "CYX"
+            else:
+                tiff_metadata["axes"] = "CZYX"
+
             if ome:
-                channel_dict = get_channel_dict(channel)
-                if channel_dict is not None:
-                    channel_kwargs["metadata"]["Channel"] = channel_dict
-            tiff.write(channel.array, **channel_kwargs)
+                try:
+                    channel_dict = get_ome_channel_dict(*channels)
+                    if channel_dict is not None:
+                        tiff_metadata["Channel"] = channel_dict
+                except UndefinedValueError as e:
+                    if not allow_missing_channel_info:
+                        logger.error("Failed to write image '%s': %s", output_path, e)
+                        raise
+                    logger.warning(
+                        "Writing without OME Channel metadata due to error: %s", e
+                    )
+            tiff.write(array, **image_kwargs)
     return output_path

--- a/src/sim_recon/main.py
+++ b/src/sim_recon/main.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from typing import Any
     from os import PathLike
     from pathlib import Path
+    from .recon import OutputFileTypes
 
 
 logger = logging.getLogger(__name__)
@@ -97,6 +98,7 @@ def sim_reconstruct(
     stitch_channels: bool = True,
     parallel_process: bool = False,
     allow_missing_channels: bool = False,
+    output_file_type: OutputFileTypes = "dv",
     **recon_kwargs: Any,
 ) -> None:
     """
@@ -122,6 +124,8 @@ def sim_reconstruct(
         Run reconstructions in 2 processes concurrently, by default False
     allow_missing_channels: bool, optional
         Attempt reconstruction of other channels in a multi-channel file if one or more are not configured, by default False
+    output_file_type: Literal["dv", "tiff"], optional
+        File type that output images will be saved as, by default "dv"
     """
     conf = load_configs(config_path, otf_overrides=otf_overrides)
     logger.info("Starting reconstructions...")
@@ -134,5 +138,6 @@ def sim_reconstruct(
         stitch_channels=stitch_channels,
         parallel_process=parallel_process,
         allow_partial=allow_missing_channels,
+        output_file_type=output_file_type,
         **recon_kwargs,
     )

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -49,10 +49,12 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Literal
+    from typing import Any, Literal, TypeAlias
     from os import PathLike
     from multiprocessing.pool import AsyncResult
     from numpy.typing import NDArray
+
+    OutputFileTypes: TypeAlias = Literal["dv", "tiff"]
 
 
 logger = logging.getLogger(__name__)
@@ -208,7 +210,7 @@ def _reconstructions_to_output(
     processing_info_dict: dict[int, ProcessingInfo],
     stitch_channels: bool = True,
     overwrite: bool = True,
-    file_type: Literal["dv", "tiff"] = "dv",
+    file_type: OutputFileTypes = "dv",
 ) -> None:
     input_dv = read_mrc_bound_array(sim_data_path).mrc
     input_resolution = image_resolution_from_mrc(input_dv, warn_not_square=False)
@@ -356,6 +358,7 @@ def run_reconstructions(
     stitch_channels: bool = True,
     parallel_process: bool = False,
     allow_missing_channels: bool = False,
+    output_file_type: OutputFileTypes = "dv",
     **config_kwargs: Any,
 ) -> None:
 
@@ -451,6 +454,7 @@ def run_reconstructions(
                             processing_info_dict=processing_info_dict,
                             stitch_channels=stitch_channels,
                             overwrite=overwrite,
+                            file_type=output_file_type
                         )
                     finally:
                         proc_log_files: list[Path] = []

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -17,15 +17,16 @@ from pycudasirecon.sim_reconstructor import SIMReconstructor, lib  # type: ignor
 from .files.utils import redirect_output_to, create_output_path, combine_text_files
 from .files.config import create_wavelength_config
 from .images import get_image_data, dv_to_tiff
-from .images.dv import write_dv
+from .images.dv import write_dv, image_resolution_from_mrc, read_mrc_bound_array
 from .images.tiff import (
     check_tiff,
     read_tiff,
     write_tiff,
-    get_combined_array_from_tiffs,
+    generate_channels_from_tiffs,
 )
 from .images.dataclasses import (
     ImageChannel,
+    ImageResolution,
     Wavelengths,
     ProcessingInfo,
     ProcessingStatus,
@@ -48,7 +49,7 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Literal
     from os import PathLike
     from multiprocessing.pool import AsyncResult
     from numpy.typing import NDArray
@@ -189,7 +190,7 @@ def reconstruct_from_processing_info(processing_info: ProcessingInfo) -> Process
     write_tiff(
         processing_info.output_path,
         ImageChannel(processing_info.wavelengths, rec_array),
-        xy_pixel_size_microns=(recon_pixel_size, recon_pixel_size),
+        resolution=ImageResolution(recon_pixel_size, recon_pixel_size),
         overwrite=True,
     )
     logger.debug(
@@ -207,7 +208,22 @@ def _reconstructions_to_output(
     processing_info_dict: dict[int, ProcessingInfo],
     stitch_channels: bool = True,
     overwrite: bool = True,
+    file_type: Literal["dv", "tiff"] = "dv",
 ) -> None:
+    input_dv = read_mrc_bound_array(sim_data_path).mrc
+    input_resolution = image_resolution_from_mrc(input_dv, warn_not_square=False)
+    if file_type == "dv":
+        suffix = ".dv"
+        write_output = partial(
+            write_dv,
+            input_dv=input_dv,
+            overwrite=overwrite,
+        )
+    elif file_type == "tiff":
+        suffix = ".ome.tiff"
+        write_output = partial(write_tiff, ome=True, overwrite=overwrite)
+        del input_dv
+
     if stitch_channels:
         try:
             # Get zoom factors to for checking if the output can be stitched
@@ -225,34 +241,35 @@ def _reconstructions_to_output(
                     "Zoom factors are not consistent for all wavelengths"
                 )
             # Stitch channels (if requested and possible)
-            dv_path = create_output_path(
+            output_image_path = create_output_path(
                 sim_data_path,
                 output_type="recon",
-                suffix=".dv",
+                suffix=suffix,
                 output_directory=file_output_directory,
                 ensure_unique=not overwrite,
             )
 
-            output_files = tuple(
-                pi.output_path
+            output_wavelengths_path_tuples = tuple(
+                (pi.wavelengths, pi.output_path)
                 for pi in processing_info_dict.values()
                 if pi.status == ProcessingStatus.COMPLETE
             )
-            if not output_files:
+            if not output_wavelengths_path_tuples:
                 logger.warning(
                     "No reconstructions were created from %s",
                     sim_data_path,
                 )
             else:
-                write_dv(
-                    sim_data_path,
-                    dv_path,
-                    get_combined_array_from_tiffs(*output_files),
-                    wavelengths=tuple(processing_info_dict.keys()),
-                    zoomfact=float(zoom_factors[0][0]),
-                    zzoom=zoom_factors[0][1],
-                    overwrite=overwrite,
-                )
+                zoom_fact = float(zoom_factors[0][0])
+                zzoom = zoom_factors[0][1]
+                write_output(
+                    output_image_path,
+                    *generate_channels_from_tiffs(*output_wavelengths_path_tuples),
+                    resolution=ImageResolution(
+                        input_resolution.x / zoom_fact,
+                        input_resolution.y / zoom_fact,
+                        input_resolution.z / zzoom,
+                    ))
             return
         except InvalidValueError as e:
             logger.warning("Unable to stitch files due to error: %s", e)
@@ -263,22 +280,24 @@ def _reconstructions_to_output(
     ) in processing_info_dict.items():
         if processing_info.status != ProcessingStatus.COMPLETE:
             continue
-        dv_path = create_output_path(
+        output_image_path = create_output_path(
             sim_data_path,
             output_type="recon",
-            suffix=".dv",
+            suffix=suffix,
             output_directory=file_output_directory,
             wavelength=wavelength,
             ensure_unique=not overwrite,
         )
-
-        write_dv(
-            sim_data_path,
-            dv_path,
-            get_combined_array_from_tiffs(processing_info.output_path),
-            wavelengths=(wavelength,),
-            zoomfact=float(processing_info.kwargs["zoomfact"]),
-            zzoom=processing_info.kwargs["zzoom"],
+        zoom_fact = float(processing_info.kwargs["zoomfact"])
+        zzoom = processing_info.kwargs["zzoom"]
+        write_output(
+            output_image_path,
+            *generate_channels_from_tiffs((processing_info.wavelengths, processing_info.output_path)),
+            resolution=ImageResolution(
+                input_resolution.x / zoom_fact,
+                input_resolution.y / zoom_fact,
+                input_resolution.z / zzoom,
+            ),
         )
 
 
@@ -627,10 +646,7 @@ def _prepare_files(
             write_tiff(
                 split_file_path,
                 channel,
-                xy_pixel_size_microns=(
-                    image_data.resolution.x,
-                    image_data.resolution.y,
-                ),
+                resolution=image_data.resolution,
             )
 
             processing_info = create_processing_info(

--- a/src/sim_recon/recon.py
+++ b/src/sim_recon/recon.py
@@ -191,7 +191,7 @@ def reconstruct_from_processing_info(processing_info: ProcessingInfo) -> Process
     recon_pixel_size = float(processing_info.kwargs["xyres"]) / zoomfact
     write_tiff(
         processing_info.output_path,
-        ImageChannel(processing_info.wavelengths, rec_array),
+        (ImageChannel(processing_info.wavelengths, rec_array),),
         resolution=ImageResolution(recon_pixel_size, recon_pixel_size),
         overwrite=True,
     )
@@ -266,12 +266,15 @@ def _reconstructions_to_output(
                 zzoom = zoom_factors[0][1]
                 write_output(
                     output_image_path,
-                    *generate_channels_from_tiffs(*output_wavelengths_path_tuples),
+                    tuple(
+                        generate_channels_from_tiffs(*output_wavelengths_path_tuples)
+                    ),
                     resolution=ImageResolution(
                         input_resolution.x / zoom_fact,
                         input_resolution.y / zoom_fact,
                         input_resolution.z / zzoom,
-                    ))
+                    ),
+                )
             return
         except InvalidValueError as e:
             logger.warning("Unable to stitch files due to error: %s", e)
@@ -294,7 +297,11 @@ def _reconstructions_to_output(
         zzoom = processing_info.kwargs["zzoom"]
         write_output(
             output_image_path,
-            *generate_channels_from_tiffs((processing_info.wavelengths, processing_info.output_path)),
+            tuple(
+                generate_channels_from_tiffs(
+                    (processing_info.wavelengths, processing_info.output_path)
+                )
+            ),
             resolution=ImageResolution(
                 input_resolution.x / zoom_fact,
                 input_resolution.y / zoom_fact,
@@ -454,7 +461,7 @@ def run_reconstructions(
                             processing_info_dict=processing_info_dict,
                             stitch_channels=stitch_channels,
                             overwrite=overwrite,
-                            file_type=output_file_type
+                            file_type=output_file_type,
                         )
                     finally:
                         proc_log_files: list[Path] = []
@@ -649,7 +656,7 @@ def _prepare_files(
             )
             write_tiff(
                 split_file_path,
-                channel,
+                (channel,),
                 resolution=image_data.resolution,
             )
 


### PR DESCRIPTION
DV file is a bit specialised and it was fairly easy to make this change using the existing code. Had some trouble with the channels being saved as separate images, according to the OME-TIFF metadata, but that's fixed now.